### PR TITLE
Fixes issue connecting to SQL DB

### DIFF
--- a/learnr-with-alex/r-learnr-with-alex.Rmd
+++ b/learnr-with-alex/r-learnr-with-alex.Rmd
@@ -306,10 +306,10 @@ knitr::include_graphics("www/sqlexercise.png",
 
 Go ahead and run the code if you like. You can also try other SQL commands in this code box. 
 
-```{r setup2, include=FALSE}
+```{r setup2, exercise = TRUE}
 # altered from https://datacarpentry.org/R-ecology-lesson/05-r-and-databases.html
 mammals <- DBI::dbConnect(RSQLite::SQLite(),
-                          "www/portal_mammals.sqlite")
+                          "../www/portal_mammals.sqlite")
 ```
 ```{sql sql-not-r, exercise = TRUE, connection="mammals", output.var='surveys', exercise.lines = 15}
 SELECT *


### PR DESCRIPTION
I noticed that on both dev and prod servers, knitr/rmarkdown only sometimes connects to the DB -- other times it does not appear to execute this code chunk at all. Setting the connection within an exercise chunk to force evaluation, along with looking for the `portal_mammals.sqlite` file a directory up (b/c SQL and Python code are executed in a subdirectory with the learnr fork), seem to fix this issue. I will look into this bug long-term, but this should work for now.